### PR TITLE
Upgrade quarto-webr extension from 0.3.0 to 0.3.6

### DIFF
--- a/_extensions/coatless/webr/_extension.yml
+++ b/_extensions/coatless/webr/_extension.yml
@@ -1,7 +1,7 @@
 name: webr
 title: Embedded webr code cells
 author: James Joseph Balamuta
-version: 0.3.0
+version: 0.3.6
 quarto-required: ">=1.2.198"
 contributes:
   filters:

--- a/_extensions/coatless/webr/monaco-editor-init.html
+++ b/_extensions/coatless/webr/monaco-editor-init.html
@@ -1,0 +1,10 @@
+<script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/loader.js"></script>
+<script type="module" id="webr-monaco-editor-init">
+
+  // Configure the Monaco Editor's loader
+  require.config({
+    paths: {
+      'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs'
+    }
+  });
+</script>

--- a/_extensions/coatless/webr/webr-context-interactive.html
+++ b/_extensions/coatless/webr/webr-context-interactive.html
@@ -1,0 +1,171 @@
+<button class="btn btn-default btn-webr" disabled type="button" id="webr-run-button-{{WEBRCOUNTER}}">Loading
+  webR...</button>
+<div id="webr-editor-{{WEBRCOUNTER}}"></div>
+<div id="webr-code-output-{{WEBRCOUNTER}}" aria-live="assertive">
+  <pre style="visibility: hidden"></pre>
+</div>
+<script type="module">
+  // Retrieve webR code cell information
+  const runButton = document.getElementById("webr-run-button-{{WEBRCOUNTER}}");
+  const outputDiv = document.getElementById("webr-code-output-{{WEBRCOUNTER}}");
+  const editorDiv = document.getElementById("webr-editor-{{WEBRCOUNTER}}");
+
+  // Add a light grey outline around the code editor
+  editorDiv.style.border = "1px solid #eee";
+
+  // Load the Monaco Editor and create an instance
+  let editor;
+  require(['vs/editor/editor.main'], function () {
+    editor = monaco.editor.create(editorDiv, {
+      value: `{{WEBRCODE}}`,
+      language: 'r',
+      theme: 'vs-light',
+      automaticLayout: true,           // TODO: Could be problematic for slide decks
+      scrollBeyondLastLine: false,
+      minimap: {
+        enabled: false
+      },
+      fontSize: '17.5rem',               // Bootstrap is 1 rem
+      renderLineHighlight: "none",     // Disable current line highlighting
+      hideCursorInOverviewRuler: true  // Remove cursor indictor in right hand side scroll bar
+    });
+
+    // Dynamically modify the height of the editor window if new lines are added.
+    let ignoreEvent = false;
+    const updateHeight = () => {
+      const contentHeight = editor.getContentHeight();
+      // We're avoiding a width change
+      //editorDiv.style.width = `${width}px`;
+      editorDiv.style.height = `${contentHeight}px`;
+      try {
+        ignoreEvent = true;
+
+        // The key to resizing is this call
+        editor.layout();
+      } finally {
+        ignoreEvent = false;
+      }
+    };
+
+    // Registry of keyboard shortcuts that should be re-added to each editor window
+    // when focus changes.
+    const addWebRKeyboardShortCutCommands = () => {
+      // Add a keydown event listener for Shift+Enter to run all code in cell
+      editor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, () => {
+
+        // Retrieve all text inside the editor
+        executeCode(editor.getValue());
+      });
+
+      // Add a keydown event listener for CMD/Ctrl+Enter to run selected code
+      editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+        // Get the selected text from the editor
+        const selectedText = editor.getModel().getValueInRange(editor.getSelection());
+        // Code to run when Ctrl+Enter is pressed (run selected code)
+        executeCode(selectedText);
+      });
+    }
+
+    // Register an on focus event handler for when a code cell is selected to update
+    // what keyboard shortcut commands should work.
+    // This is a workaround to fix a regression that happened with multiple
+    // editor windows since Monaco 0.32.0 
+    // https://github.com/microsoft/monaco-editor/issues/2947
+    editor.onDidFocusEditorText(addWebRKeyboardShortCutCommands);
+
+    // Register an on change event for when new code is added to the editor window
+    editor.onDidContentSizeChange(updateHeight);
+
+    // Manually re-update height to account for the content we inserted into the call
+    updateHeight();
+  });
+
+  // Function to execute the code (accepts code as an argument)
+  async function executeCode(codeToRun) {
+    // Disable run button for code cell active
+    runButton.disabled = true;
+
+    // Create a canvas variable for graphics
+    let canvas = undefined;
+
+    // Initialize webR
+    await globalThis.webR.init();
+
+    // Setup a webR canvas by making a namespace call into the {webr} package
+    await webR.evalRVoid("webr::canvas(width={{WIDTH}}, height={{HEIGHT}})");
+
+    // Capture output data from evaluating the code
+    const result = await webRCodeShelter.captureR(codeToRun, {
+      withAutoprint: true,
+      captureStreams: true,
+      captureConditions: false//,
+      // env: webR.objs.emptyEnv, // maintain a global environment for webR v0.2.0
+    });
+
+    // Start attempting to parse the result data
+    try {
+
+      // Stop creating images
+      await webR.evalRVoid("dev.off()");
+
+      // Merge output streams of STDOUT and STDErr (messages and errors are combined.)
+      const out = result.output.filter(
+        evt => evt.type == "stdout" || evt.type == "stderr"
+      ).map((evt) => evt.data).join("\n");
+
+      // Clean the state
+      const msgs = await webR.flush();
+
+      // Output each image stored
+      msgs.forEach(msg => {
+        // Determine if old canvas can be used or a new canvas is required.
+        if (msg.type === 'canvas'){
+          // Add image to the current canvas
+          if (msg.data.event === 'canvasImage') {
+            canvas.getContext('2d').drawImage(msg.data.image, 0, 0);
+          } else if (msg.data.event === 'canvasNewPage') {
+            // Generate a new canvas element
+            canvas = document.createElement("canvas");
+            canvas.setAttribute("width", 2 * {{WIDTH}});
+            canvas.setAttribute("height", 2 * {{HEIGHT}});
+            canvas.style.width = "700px";
+            canvas.style.display = "block";
+            canvas.style.margin = "auto";
+          }
+        }
+      });
+
+      // Nullify the outputDiv of content
+      outputDiv.innerHTML = "";
+
+      // Design an output object for messages
+      const pre = document.createElement("pre");
+      if (/\S/.test(out)) {
+        // Display results as text
+        const code = document.createElement("code");
+        code.innerText = out;
+        pre.appendChild(code);
+      } else {
+        // If nothing is present, hide the element.
+        pre.style.visibility = "hidden";
+      }
+      outputDiv.appendChild(pre);
+
+      // Place the graphics on the canvas
+      if (canvas) {
+        const p = document.createElement("p");
+        p.appendChild(canvas);
+        outputDiv.appendChild(p);
+      }
+    } finally {
+      // Clean up the remaining code
+      webRCodeShelter.purge();
+      runButton.disabled = false;
+    }
+  }
+
+  // Add a click event listener to the run button
+  runButton.onclick = function () {
+    executeCode(editor.getValue());
+  };
+</script>

--- a/_extensions/coatless/webr/webr-context-output.html
+++ b/_extensions/coatless/webr/webr-context-output.html
@@ -1,0 +1,90 @@
+<div id="webr-code-output-{{WEBRCOUNTER}}" aria-live="assertive">
+  <pre style="visibility: hidden"></pre>
+</div>
+<script type="module">
+  // Retrieve webR code cell information
+  const outputDiv = document.getElementById("webr-code-output-{{WEBRCOUNTER}}");
+  
+  // Function to execute the code (accepts code as an argument)
+  async function executeOutputOnlyCode(codeToRun) {  
+    // Create a canvas variable for graphics
+    let canvas = undefined;
+
+    // Initialize webR
+    await globalThis.webR.init();
+
+    // Setup a webR canvas by making a namespace call into the {webr} package
+    await webR.evalRVoid("webr::canvas(width={{WIDTH}}, height={{HEIGHT}})");
+
+    // Capture output data from evaluating the code
+    const result = await webRCodeShelter.captureR(codeToRun, {
+      withAutoprint: true,
+      captureStreams: true,
+      captureConditions: false//,
+      // env: webR.objs.emptyEnv, // maintain a global environment for webR v0.2.0
+    });
+
+    // Start attempting to parse the result data
+    try {
+
+      // Stop creating images
+      await webR.evalRVoid("dev.off()");
+
+      // Merge output streams of STDOUT and STDErr (messages and errors are combined.)
+      const out = result.output.filter(
+        evt => evt.type == "stdout" || evt.type == "stderr"
+      ).map((evt) => evt.data).join("\n");
+
+      // Clean the state
+      const msgs = await webR.flush();
+
+      // Output each image stored
+      msgs.forEach(msg => {
+        // Determine if old canvas can be used or a new canvas is required.
+        if (msg.type === 'canvas'){
+          // Add image to the current canvas
+          if (msg.data.event === 'canvasImage') {
+            canvas.getContext('2d').drawImage(msg.data.image, 0, 0);
+          } else if (msg.data.event === 'canvasNewPage') {
+            // Generate a new canvas element
+            canvas = document.createElement("canvas");
+            canvas.setAttribute("width", 2 * {{WIDTH}});
+            canvas.setAttribute("height", 2 * {{HEIGHT}});
+            canvas.style.width = "700px";
+            canvas.style.display = "block";
+            canvas.style.margin = "auto";
+          }
+        }
+      });
+
+      // Nullify the outputDiv of content
+      outputDiv.innerHTML = "";
+
+      // Design an output object for messages
+      const pre = document.createElement("pre");
+      if (/\S/.test(out)) {
+        // Display results as text
+        const code = document.createElement("code");
+        code.innerText = out;
+        pre.appendChild(code);
+      } else {
+        // If nothing is present, hide the element.
+        pre.style.visibility = "hidden";
+      }
+      outputDiv.appendChild(pre);
+
+      // Place the graphics on the canvas
+      if (canvas) {
+        const p = document.createElement("p");
+        p.appendChild(canvas);
+        outputDiv.appendChild(p);
+      }
+    } finally {
+      // Clean up the remaining code
+      webRCodeShelter.purge();
+    }
+  }
+
+  // Run the code
+  executeOutputOnlyCode(`{{WEBRCODE}}`)
+</script>

--- a/_extensions/coatless/webr/webr-context-setup.html
+++ b/_extensions/coatless/webr/webr-context-setup.html
@@ -1,0 +1,9 @@
+<script type="module">
+// Initialization WebR
+await globalThis.webR.init();
+
+// Run R code without focusing on storing data.
+await globalThis.webR.evalRVoid(`
+{{WEBRCODE}}
+`)
+</script>	

--- a/_extensions/coatless/webr/webr-init.html
+++ b/_extensions/coatless/webr/webr-init.html
@@ -1,4 +1,5 @@
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/monaco-editor@0.31.0/min/vs/editor/editor.main.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/editor/editor.main.css" />
+
 <style>
   .monaco-editor pre {
     background-color: unset !important;
@@ -7,19 +8,40 @@
   .btn-webr {
     background-color: #EEEEEE;
     border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-bottom-right-radius: 0; /* Extra styling for consistency */
+    display: inline-block;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #000;
+    text-align: center;
+    text-decoration: none;
+    -webkit-text-decoration: none;
+    -moz-text-decoration: none;
+    -ms-text-decoration: none;
+    -o-text-decoration: none;
+    vertical-align: middle;
+    -webkit-user-select: none;
+    border-color: #dee2e6;
+    border: 1px solid rgba(0,0,0,0);
+    padding: 0.375rem 0.75rem;
+    font-size: 1rem;
+    border-radius: 0.25rem;
+    transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+  }
+
+  .btn-webr:hover {
+    color: #000;
+    background-color: #e3e6ea;
+    border-color: #e1e5e9;
+  }
+
+  .btn-webr:disabled,.btn-webr.disabled,fieldset:disabled .btn-webr {
+    pointer-events: none;
+    opacity: .65
   }
 </style>
-<script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.31.0/min/vs/loader.js"></script>
+
 <script type="module">
-
-  // Configure the Monaco Editor's loader
-  require.config({
-    paths: {
-      'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.31.0/min/vs'
-    }
-  });
-
 
   // Start a timer
   const initializeWebRTimerStart = performance.now();
@@ -74,19 +96,34 @@
     quartoTitleMeta.appendChild(firstInnerDiv);
 
     // Add new element as last child in header element
-    var header = document.getElementsByTagName("header")[0];
-    header.appendChild(quartoTitleMeta);
+    var header = document.getElementById("title-block-header");
+
+    // Check if the header option is present or missing
+    if(header) {
+      // If present, directly append the child element.
+      header.appendChild(quartoTitleMeta);
+    } else {
+      // Attempt to place the new element inside a header _after_ the Monaco initialization
+      var monacoScript = document.getElementById("webr-monaco-editor-init");
+      var header = document.createElement("header");
+      header.setAttribute("id", "title-block-header");
+      // Now attempt to add the webR area to the title
+      header.appendChild(quartoTitleMeta);
+      // Include the header after the script tag
+      monacoScript.after(header);
+    }
   }
 
   // Retrieve the webr.mjs
-  import { WebR } from "https://webr.r-wasm.org/v0.2.0/webr.mjs";
+  import { WebR, ChannelType } from "https://webr.r-wasm.org/v0.2.1/webr.mjs";
 
   // Populate WebR options with defaults or new values based on 
   // webr meta
   globalThis.webR = new WebR({
     "baseURL": "{{BASEURL}}",
     "serviceWorkerUrl": "{{SERVICEWORKERURL}}",
-    "homedir": "{{HOMEDIR}}"
+    "homedir": "{{HOMEDIR}}", 
+    "channelType": {{CHANNELTYPE}}
   });
 
   // Initialization WebR

--- a/_extensions/coatless/webr/webr-serviceworker.js
+++ b/_extensions/coatless/webr/webr-serviceworker.js
@@ -1,1 +1,1 @@
-importScripts('https://webr.r-wasm.org/v0.2.0/webr-serviceworker.js');
+importScripts('https://webr.r-wasm.org/v0.2.1/webr-serviceworker.js');

--- a/_extensions/coatless/webr/webr-worker.js
+++ b/_extensions/coatless/webr/webr-worker.js
@@ -1,1 +1,1 @@
-importScripts('https://webr.r-wasm.org/v0.2.0/webr-worker.js');
+importScripts('https://webr.r-wasm.org/v0.2.1/webr-worker.js');

--- a/_extensions/coatless/webr/webr.lua
+++ b/_extensions/coatless/webr/webr.lua
@@ -9,11 +9,18 @@ local hasDoneWebRSetup = false
 -- https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html
 
 -- Define a base compatibile version
-local baseVersionWebR = "0.1.1"
+local baseVersionWebR = "0.2.1"
 
 -- Define where WebR can be found
 local baseUrl = ""
 local serviceWorkerUrl = ""
+
+-- Define the webR communication protocol
+local channelType = "ChannelType.Automatic"
+
+-- Define a variable to suppress exporting service workers if not required.
+-- (e.g. skipped for PostMessage or SharedArrayBuffer)
+local hasServiceWorkerFiles = true
 
 -- Define user directory
 local homeDir = "/home/web_user"
@@ -40,6 +47,25 @@ local counter = 0
 function is_variable_empty(s)
   return s == nil or s == ''
 end
+
+-- Convert the communication channel meta option into a WebROptions.channelType option
+function convertMetaChannelTypeToWebROption(input)
+  -- Create a table of conditions
+  local conditions = {
+    ["automatic"] = "ChannelType.Automatic",
+    [0] = "ChannelType.Automatic",
+    ["shared-array-buffer"] = "ChannelType.SharedArrayBuffer",
+    [1] = "ChannelType.SharedArrayBuffer",
+    ["service-worker"] = "ChannelType.ServiceWorker",
+    [2] = "ChannelType.ServiceWorker",
+    ["post-message"] = "ChannelType.PostMessage",
+    [3] = "ChannelType.PostMessage",
+  }
+  -- Subset the table to obtain the communication channel.
+  -- If the option isn't found, return automatic.
+  return conditions[input] or "ChannelType.Automatic"
+end
+
 
 -- Parse the different webr options set in the YAML frontmatter, e.g.
 --
@@ -71,6 +97,17 @@ function setWebRInitializationOptions(meta)
   -- https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#baseurl
   if not is_variable_empty(webr["base-url"]) then
     baseUrl = pandoc.utils.stringify(webr["base-url"])
+  end
+
+  -- The communication channel mode webR uses to connect R with the web browser 
+  -- Default: "ChannelType.Automatic"
+  -- Documentation:
+  -- https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#channeltype
+  if not is_variable_empty(webr["channel-type"]) then
+    channelType = convertMetaChannelTypeToWebROption(pandoc.utils.stringify(webr["channel-type"]))
+    if not (channelType == "ChannelType.Automatic" and channelType == "ChannelType.ServiceWorker") then
+      hasServiceWorkerFiles = false
+    end
   end
 
   -- The base URL from where to load JavaScript worker scripts when loading webR
@@ -148,9 +185,19 @@ function readTemplateFile(template)
   return content
 end
 
--- Obtain the editor template file at webr-editor.html
-function editorTemplateFile()
-  return readTemplateFile("webr-editor.html")
+-- Obtain the editor template file at webr-context-interactive.html
+function interactiveTemplateFile()
+  return readTemplateFile("webr-context-interactive.html")
+end
+
+-- Obtain the output template file at webr-context-output.html
+function outputTemplateFile()
+  return readTemplateFile("webr-context-output.html")
+end
+
+-- Obtain the setup template file at webr-context-setup.html
+function setupTemplateFile()
+  return readTemplateFile("webr-context-setup.html")
 end
 
 -- Obtain the initialization template file at webr-init.html
@@ -158,8 +205,12 @@ function initializationTemplateFile()
   return readTemplateFile("webr-init.html")
 end
 
--- Cache a copy of the template to avoid multiple read/writes.
-editor_template = editorTemplateFile()
+-- Cache a copy of each public-facing templates to avoid multiple read/writes.
+interactive_template = interactiveTemplateFile()
+
+output_template = outputTemplateFile()
+
+setup_template = setupTemplateFile()
 ----
 
 -- Define a function that escape control sequence
@@ -238,6 +289,7 @@ function initializationWebR()
     ["SHOWSTARTUPMESSAGE"] = showStartUpMessage, -- tostring()
     ["SHOWHEADERMESSAGE"] = showHeaderMessage,
     ["BASEURL"] = baseUrl, 
+    ["CHANNELTYPE"] = channelType,
     ["SERVICEWORKERURL"] = serviceWorkerUrl, 
     ["HOMEDIR"] = homeDir,
     ["INSTALLRPACKAGESLIST"] = installRPackagesList
@@ -270,22 +322,29 @@ function ensureWebRSetup()
   -- https://quarto.org/docs/extensions/lua-api.html#includes
   quarto.doc.include_text("in-header", initializedConfigurationWebR)
 
-  -- Copy the two web workers into the directory
-  -- https://quarto.org/docs/extensions/lua-api.html#dependencies
+  -- Insert the monaco editor initialization
+  quarto.doc.include_file("before-body", "monaco-editor-init.html")
 
-  quarto.doc.add_html_dependency({
-    name = "webr-worker",
-    version = baseVersionWebR,
-    seviceworkers = {"webr-worker.js"}, -- Kept to avoid error text.
-    serviceworkers = {"webr-worker.js"}
-  })
+  -- If the ChannelType requires service workers, register and copy them into the 
+  -- output directory.
+  if hasServiceWorkerFiles then 
+    -- Copy the two web workers into the directory
+    -- https://quarto.org/docs/extensions/lua-api.html#dependencies
+    quarto.doc.add_html_dependency({
+      name = "webr-worker",
+      version = baseVersionWebR,
+      seviceworkers = {"webr-worker.js"}, -- Kept to avoid error text.
+      serviceworkers = {"webr-worker.js"}
+    })
 
-  quarto.doc.add_html_dependency({
-    name = "webr-serviceworker",
-    version = baseVersionWebR,
-    seviceworkers = {"webr-serviceworker.js"}, -- Kept to avoid error text.
-    serviceworkers = {"webr-serviceworker.js"}
-  })
+    quarto.doc.add_html_dependency({
+      name = "webr-serviceworker",
+      version = baseVersionWebR,
+      seviceworkers = {"webr-serviceworker.js"}, -- Kept to avoid error text.
+      serviceworkers = {"webr-serviceworker.js"}
+    })
+  end
+
 end
 
 -- Define a function to replace keywords given by {{ WORD }}
@@ -299,6 +358,44 @@ function substitute_in_file(contents, substitutions)
   return contents
 end
 
+-- Extract Quarto code cell options from the block's text
+function extractCodeBlockOptions(block)
+  
+  -- Access the text aspect of the code block
+  local code = block.text
+
+  -- Define two local tables:
+  --  the block's attributes
+  --  the block's code lines
+  local newAttributes = {}
+  local newCodeLines = {}
+
+  -- Iterate over each line in the code block 
+  for line in code:gmatch("([^\r\n]*)[\r\n]?") do
+    -- Check if the line starts with "#|" and extract the key-value pairing
+    -- e.g. #| key: value goes to newAttributes[key] -> value
+    local key, value = line:match("^#|%s*(.-):%s*(.-)%s*$")
+
+    -- If a special comment is found, then add the key-value pairing to the newAttributes table
+    if key and value then
+      newAttributes[key] = value
+    else
+      -- Otherwise, it's not a special comment, keep the code line
+      table.insert(newCodeLines, line)
+    end
+  end
+
+  -- Set the new attributes for the code block
+  block.attributes = newAttributes
+
+  -- Set the codeblock text to exclude the special comments.
+  block.text = table.concat(newCodeLines, '\n')
+
+  -- Return the full block
+  return block
+end
+
+-- Replace the code cell with a webR editor
 function enableWebRCodeCell(el)
       
   -- Let's see what's going on here:
@@ -333,6 +430,9 @@ function enableWebRCodeCell(el)
       -- Modify the counter variable each time this is run to create
       -- unique code cells
       counter = counter + 1
+
+      -- Convert webr-specific option commands into attributes
+      el = extractCodeBlockOptions(el)
       
       -- 7 is the default height and width for knitr. But, that doesn't translate to pixels.
       -- So, we have 504 and 360 respectively.
@@ -345,14 +445,28 @@ function enableWebRCodeCell(el)
         ["WEBRCODE"] = escapeControlSequences(el.text)
       }
       
-      -- Make sure we perform a copy
-      local copied_editor_template = editor_template
+      -- Retrieve the newly defined attributes
+      local cell_context = el.attributes.context
 
-      -- Make the necessary substitutions
-      local webr_enabled_code_cell = substitute_in_file(copied_editor_template, substitutions)
+      -- Decide the correct template
+      -- Make sure we perform a copy of each template
+      local copied_code_template = nil
+      if is_variable_empty(cell_context) or cell_context == "interactive" then
+        copied_code_template = interactive_template
+      elseif cell_context == "setup" then
+        copied_code_template = setup_template
+      elseif cell_context == "output" then
+        copied_code_template = output_template
+      else
+        error("The `context` option must contain either: `interactive`, `setup`, or `output`. Not the value of `".. cell_context .."`")
+      end
+
+      -- Make the necessary substitutions into the template
+      local webr_enabled_code_cell = substitute_in_file(copied_code_template, substitutions)
 
       -- Return the modified HTML template as a raw cell
       return pandoc.RawInline('html', webr_enabled_code_cell)
+
     end
   end
   -- Allow for a pass through in other languages

--- a/webR_test.qmd
+++ b/webR_test.qmd
@@ -6,10 +6,6 @@ webr:
 
 This is a WebR-enabled code cell in a Quarto HTML document. As the WebR documentation states: "WebR makes it possible to run R code in the browser without the need for an R server to execute the code: the R interpreter runs directly on the user’s machine."
 
-::: callout-warning
-Use a Chrome or Firefox browser - WebR does not work with the Safari browser yet. If the following WebR chunk is working properly, you should see an editor window below the `Run code` tab displaying two lines of R code. 
-:::
-
 ```{webr-r}
 # Edit/add code here
 fit = lm(mpg ~ am, data = mtcars)
@@ -20,5 +16,5 @@ ggplot(mtcars, aes(x=am,y=mpg)) +
    geom_smooth(method="lm")
 ```
 
-Link: [WebR](https://docs.r-wasm.org/webr/latest/).
+Link: [WebR](https://docs.r-wasm.org/webr/latest/) and [`quarto-webr`](http://quarto-webr.thecoatlessprofessor.com/).
 ---


### PR DESCRIPTION
@DanielEWeeks this PR updates the `quarto-webr` extension version referenced in the book. We fixed the Safari snafu in 0.3.2, so we've removed the disclaimer text above the code cell.